### PR TITLE
Update dependencies and fix external syntax.

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,12 +10,12 @@ version = "0.1.0"
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.19"
-gleam_http = "~> 3.0"
-gleam_erlang = "~> 0.9"
-gleam_crypto = "~> 0.3"
-mist = "~> 0.4"
-sqlight = "~> 0.4"
+gleam_stdlib = "~> 0.31"
+gleam_http = "~> 3.5"
+gleam_erlang = "~> 0.22"
+gleam_crypto = "~> 0.4"
+mist = "~> 0.14"
+sqlight = "~> 0.8"
 
 [dev-dependencies]
-gleeunit = "~> 0.6"
+gleeunit = "~> 0.11"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,23 +3,23 @@
 
 packages = [
   { name = "esqlite", version = "0.8.6", build_tools = ["rebar3"], requirements = [], otp_app = "esqlite", source = "hex", outer_checksum = "607E45F4DA42601D8F530979417F57A4CD629AB49085891849302057E68EA188" },
-  { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
-  { name = "gleam_crypto", version = "0.3.1", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "C356D26C3EDFF495F2C73378C4D9C47435F729F5852ECA8CD6F635515317E630" },
-  { name = "gleam_erlang", version = "0.18.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C69F59D086AD50B80DE294FB0963550630971C9DC04E92B1F7AEEDD2C0BE226C" },
-  { name = "gleam_http", version = "3.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "7BE7A80B5AC8357827169107FAE15AD8423629E6BBBD39A8B4217AFF879B4520" },
-  { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
-  { name = "gleam_stdlib", version = "0.28.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1BB6A3E53F7576B9F5C4E5D4AE16487E526BE383B03CBF4068C7DFC77CF38A1C" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "glisten", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_stdlib", "gleam_erlang"], otp_app = "glisten", source = "hex", outer_checksum = "52B530FF25370590843998D1B6C4EC6169DB1300D5E4407A5CDA1575374B7AEC" },
-  { name = "mist", version = "0.10.0", build_tools = ["gleam"], requirements = ["glisten", "gleam_http", "gleam_erlang", "gleam_stdlib", "gleam_otp"], otp_app = "mist", source = "hex", outer_checksum = "5AFBABABF738BAB8720F047471051E4E9D102CA4694C120DB899FA12AD5D180B" },
-  { name = "sqlight", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "esqlite"], otp_app = "sqlight", source = "hex", outer_checksum = "082244304DE85652A5BCF31CFE891BB8E96017B0A4BEA43623D32CC0983BF699" },
+  { name = "gleam_bitwise", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "E2A46EE42E5E9110DAD67E0F71E7358CBE54D5EC22C526DD48CBBA3223025792" },
+  { name = "gleam_crypto", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "42429CED0F838B40014E1C017B0495C46C311D08035D2C2D43B749B91A4374F6" },
+  { name = "gleam_erlang", version = "0.22.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "367D8B41A7A86809928ED1E7E55BFD0D46D7C4CF473440190F324AFA347109B4" },
+  { name = "gleam_http", version = "3.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FAE9AE3EB1CA90C2194615D20FFFD1E28B630E84DACA670B28D959B37BCBB02C" },
+  { name = "gleam_otp", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "ED7381E90636E18F5697FD7956EECCA635A3B65538DC2BE2D91A38E61DCE8903" },
+  { name = "gleam_stdlib", version = "0.31.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6D1BC5B4D4179B9FEE866B1E69FE180AC2CE485AD90047C0B32B2CA984052736" },
+  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
+  { name = "glisten", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_erlang", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "2F91A3E8717DE46E45296E3332B3E51B16B69CB65083C2A8257E492319D70D03" },
+  { name = "mist", version = "0.14.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_http", "glisten", "gleam_erlang", "gleam_otp"], otp_app = "mist", source = "hex", outer_checksum = "7CDD0396D9A556F1069D83E9AF2B24388AAC478B9B4846615C6D4797E1D3C6A3" },
+  { name = "sqlight", version = "0.8.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "63001BC125F481A15D459AE883DAACB3B3CB828814DE3D885AE70CCC324C2BC2" },
 ]
 
 [requirements]
-gleam_crypto = "~> 0.3"
-gleam_erlang = "~> 0.9"
-gleam_http = "~> 3.0"
-gleam_stdlib = "~> 0.19"
-gleeunit = "~> 0.6"
-mist = "~> 0.4"
-sqlight = "~> 0.4"
+gleam_crypto = { version = "~> 0.4" }
+gleam_erlang = { version = "~> 0.22" }
+gleam_http = { version = "~> 3.5" }
+gleam_stdlib = { version = "~> 0.31" }
+gleeunit = { version = "~> 0.11" }
+mist = { version = "~> 0.14" }
+sqlight = { version = "~> 0.8" }

--- a/src/todomvc/log.gleam
+++ b/src/todomvc/log.gleam
@@ -14,11 +14,11 @@ pub type Level {
 /// Configure the Erlang logger to use the log level and output format that we
 /// want, rather than the more verbose Erlang default format.
 ///
-pub external fn configure_backend() -> Nil =
-  "todomvc_ffi" "configure_logger_backend"
+@external(erlang, "todomvc_ffi", "configure_logger_backend")
+pub fn configure_backend() -> Nil
 
-external fn erlang_log(Level, String) -> Dynamic =
-  "logger" "log"
+@external(erlang, "logger", "log")
+fn erlang_log(level: Level, message: String) -> Dynamic
 
 pub fn log(level: Level, message: String) -> Nil {
   erlang_log(level, message)

--- a/src/todomvc/web/log_requests.gleam
+++ b/src/todomvc/web/log_requests.gleam
@@ -41,8 +41,8 @@ type TimeUnit {
   Microsecond
 }
 
-external fn now() -> Int =
-  "erlang" "monotonic_time"
+@external(erlang, "erlang", "monotonic_time")
+fn now() -> Int
 
-external fn convert_time_unit(Int, TimeUnit, TimeUnit) -> Int =
-  "erlang" "convert_time_unit"
+@external(erlang, "erlang", "convert_time_unit")
+fn convert_time_unit(time: Int, from: TimeUnit, to: TimeUnit) -> Int

--- a/src/todomvc/web/static.gleam
+++ b/src/todomvc/web/static.gleam
@@ -28,5 +28,5 @@ pub fn middleware(
   }
 }
 
-external fn priv_directory() -> String =
-  "todomvc_ffi" "priv_directory"
+@external(erlang, "todomvc_ffi", "priv_directory")
+fn priv_directory() -> String

--- a/test/todomvc/tests.gleam
+++ b/test/todomvc/tests.gleam
@@ -46,5 +46,5 @@ cascade
   Nil
 }
 
-pub external fn ensure(run: fn() -> a, afterwards: fn() -> b) -> a =
-  "todomvc_test_helper" "ensure"
+@external(erlang, "todomvc_test_helper", "ensure")
+pub fn ensure(run: fn() -> a, afterwards: fn() -> b) -> a


### PR DESCRIPTION
Because gleam couldn't compile version 0.28.0 of gleam_stdlib, I decided to upgrade all dependencies and move over to the new syntax for external.

Creating the mist server is still not working, yet. They changed their API in 0.13, and older versions do not compile any more.

I'm not yet familiar enough with gleam to fix this issue completely, because I wanted to use this repo to get into
functional programming and gleam.